### PR TITLE
Migration from org.jacoco to za.co.absa.jacoco

### DIFF
--- a/jacoco-maven-plugin.test/it/setup-parent/invoker.properties
+++ b/jacoco-maven-plugin.test/it/setup-parent/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals = org.jacoco:jacoco-maven-plugin:${project.version}:help install
+invoker.goals = za.co.absa.jacoco:jacoco-maven-plugin:${project.version}:help install

--- a/jacoco-maven-plugin.test/pom.xml
+++ b/jacoco-maven-plugin.test/pom.xml
@@ -15,7 +15,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.tests</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.tests</relativePath>
@@ -53,7 +53,7 @@
           </goals>
           <settingsFile>it/settings.xml</settingsFile>
           <extraArtifacts>
-            <extraArtifact>org.jacoco:org.jacoco.agent:${project.version}:jar:runtime</extraArtifact>
+            <extraArtifact>za.co.absa.jacoco:org.jacoco.agent:${project.version}:jar:runtime</extraArtifact>
           </extraArtifacts>
           <properties>
             <!--

--- a/jacoco-maven-plugin/pom.xml
+++ b/jacoco-maven-plugin/pom.xml
@@ -15,7 +15,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.build</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.build</relativePath>

--- a/jacoco-maven-plugin/src/org/jacoco/maven/AbstractAgentMojo.java
+++ b/jacoco-maven-plugin/src/org/jacoco/maven/AbstractAgentMojo.java
@@ -31,7 +31,7 @@ public abstract class AbstractAgentMojo extends AbstractJacocoMojo {
 	/**
 	 * Name of the JaCoCo Agent artifact.
 	 */
-	static final String AGENT_ARTIFACT_NAME = "org.jacoco:org.jacoco.agent";
+	static final String AGENT_ARTIFACT_NAME = "za.co.absa.jacoco:org.jacoco.agent";
 	/**
 	 * Name of the property used in maven-osgi-test-plugin.
 	 */

--- a/jacoco/pom.xml
+++ b/jacoco/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.build</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.build</relativePath>

--- a/org.jacoco.agent.rt.test/pom.xml
+++ b/org.jacoco.agent.rt.test/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.tests</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.tests</relativePath>

--- a/org.jacoco.agent.rt/pom.xml
+++ b/org.jacoco.agent.rt/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.build</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.build</relativePath>

--- a/org.jacoco.agent.test/pom.xml
+++ b/org.jacoco.agent.test/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.tests</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.tests</relativePath>

--- a/org.jacoco.agent/pom.xml
+++ b/org.jacoco.agent/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.build</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.build</relativePath>

--- a/org.jacoco.ant.test/pom.xml
+++ b/org.jacoco.ant.test/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.tests</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.tests</relativePath>

--- a/org.jacoco.ant/pom.xml
+++ b/org.jacoco.ant/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.build</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.build</relativePath>

--- a/org.jacoco.build/pom.xml
+++ b/org.jacoco.build/pom.xml
@@ -13,7 +13,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jacoco</groupId>
+  <groupId>za.co.absa.jacoco</groupId>
   <artifactId>org.jacoco.build</artifactId>
   <version>0.8.9-SNAPSHOT</version>
   <packaging>pom</packaging>
@@ -1242,7 +1242,7 @@
                     </pluginExecution>
                     <pluginExecution>
                       <pluginExecutionFilter>
-                        <groupId>org.jacoco</groupId>
+                        <groupId>za.co.absa.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
                         <versionRange>[0,)</versionRange>
                         <goals>

--- a/org.jacoco.cli.test/pom.xml
+++ b/org.jacoco.cli.test/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.tests</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.tests</relativePath>

--- a/org.jacoco.cli/pom.xml
+++ b/org.jacoco.cli/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.build</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.build</relativePath>

--- a/org.jacoco.core.test.validation.groovy/pom.xml
+++ b/org.jacoco.core.test.validation.groovy/pom.xml
@@ -15,7 +15,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.core.test.validation</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.core.test.validation</relativePath>

--- a/org.jacoco.core.test.validation.java14/pom.xml
+++ b/org.jacoco.core.test.validation.java14/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.core.test.validation</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.core.test.validation</relativePath>

--- a/org.jacoco.core.test.validation.java16/pom.xml
+++ b/org.jacoco.core.test.validation.java16/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.core.test.validation</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.core.test.validation</relativePath>

--- a/org.jacoco.core.test.validation.java20/pom.xml
+++ b/org.jacoco.core.test.validation.java20/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.core.test.validation</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.core.test.validation</relativePath>

--- a/org.jacoco.core.test.validation.java5/pom.xml
+++ b/org.jacoco.core.test.validation.java5/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.core.test.validation</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.core.test.validation</relativePath>

--- a/org.jacoco.core.test.validation.java7/pom.xml
+++ b/org.jacoco.core.test.validation.java7/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.core.test.validation</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.core.test.validation</relativePath>

--- a/org.jacoco.core.test.validation.java8/pom.xml
+++ b/org.jacoco.core.test.validation.java8/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.core.test.validation</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.core.test.validation</relativePath>

--- a/org.jacoco.core.test.validation.kotlin/pom.xml
+++ b/org.jacoco.core.test.validation.kotlin/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.core.test.validation</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.core.test.validation</relativePath>

--- a/org.jacoco.core.test.validation.scala/pom.xml
+++ b/org.jacoco.core.test.validation.scala/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.core.test.validation</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.core.test.validation</relativePath>

--- a/org.jacoco.core.test.validation/pom.xml
+++ b/org.jacoco.core.test.validation/pom.xml
@@ -15,7 +15,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.tests</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.tests</relativePath>

--- a/org.jacoco.core.test/pom.xml
+++ b/org.jacoco.core.test/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.tests</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.tests</relativePath>

--- a/org.jacoco.core/pom.xml
+++ b/org.jacoco.core/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.build</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.build</relativePath>

--- a/org.jacoco.doc/pom.xml
+++ b/org.jacoco.doc/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.build</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.build</relativePath>
@@ -120,7 +120,7 @@
 
     <plugins>
       <plugin>
-        <groupId>org.jacoco</groupId>
+        <groupId>za.co.absa.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>${project.version}</version>
         <executions>
@@ -202,10 +202,10 @@
               <includeDependencySources>true</includeDependencySources>
               <excludePackageNames>*.internal,org.jacoco.ant,org.jacoco.maven,org.jacoco.examples</excludePackageNames>
               <dependencySourceIncludes>
-                <dependencySourceInclude>org.jacoco:*</dependencySourceInclude>
+                <dependencySourceInclude>za.co.absa.jacoco:*</dependencySourceInclude>
               </dependencySourceIncludes>
               <dependencySourceExcludes>
-                <dependencySourceExclude>org.jacoco:*.test</dependencySourceExclude>
+                <dependencySourceExclude>za.co.absa.jacoco:*.test</dependencySourceExclude>
               </dependencySourceExcludes>
               <doctitle>JaCoCo ${qualified.bundle.version} API</doctitle>
               <windowtitle>JaCoCo ${qualified.bundle.version} API</windowtitle>

--- a/org.jacoco.examples.test/pom.xml
+++ b/org.jacoco.examples.test/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.tests</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.tests</relativePath>

--- a/org.jacoco.examples/build/pom-it.xml
+++ b/org.jacoco.examples/build/pom-it.xml
@@ -15,7 +15,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jacoco</groupId>
+  <groupId>za.co.absa.jacoco</groupId>
   <artifactId>org.jacoco.examples.maven</artifactId>
   <version>@project.version@</version>
   <packaging>jar</packaging>
@@ -40,7 +40,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jacoco</groupId>
+        <groupId>za.co.absa.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/org.jacoco.examples/build/pom-offline.xml
+++ b/org.jacoco.examples/build/pom-offline.xml
@@ -14,7 +14,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jacoco</groupId>
+  <groupId>za.co.absa.jacoco</groupId>
   <artifactId>org.jacoco.examples.maven</artifactId>
   <version>@project.version@</version>
   <packaging>jar</packaging>
@@ -31,7 +31,7 @@
     </dependency>
     <dependency>
       <!-- must be on the classpath -->
-      <groupId>org.jacoco</groupId>
+      <groupId>za.co.absa.jacoco</groupId>
       <artifactId>org.jacoco.agent</artifactId>
       <classifier>runtime</classifier>
       <version>@project.version@</version>
@@ -47,7 +47,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jacoco</groupId>
+        <groupId>za.co.absa.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/org.jacoco.examples/build/pom.xml
+++ b/org.jacoco.examples/build/pom.xml
@@ -15,7 +15,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jacoco</groupId>
+  <groupId>za.co.absa.jacoco</groupId>
   <artifactId>org.jacoco.examples.maven</artifactId>
   <version>@project.version@</version>
   <packaging>jar</packaging>
@@ -40,7 +40,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.jacoco</groupId>
+        <groupId>za.co.absa.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/org.jacoco.examples/pom.xml
+++ b/org.jacoco.examples/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.build</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.build</relativePath>

--- a/org.jacoco.report.test/pom.xml
+++ b/org.jacoco.report.test/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.tests</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.tests</relativePath>

--- a/org.jacoco.report/pom.xml
+++ b/org.jacoco.report/pom.xml
@@ -14,7 +14,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.build</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.build</relativePath>

--- a/org.jacoco.tests/pom.xml
+++ b/org.jacoco.tests/pom.xml
@@ -15,7 +15,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jacoco</groupId>
+    <groupId>za.co.absa.jacoco</groupId>
     <artifactId>org.jacoco.build</artifactId>
     <version>0.8.9-SNAPSHOT</version>
     <relativePath>../org.jacoco.build</relativePath>
@@ -59,7 +59,7 @@
 
     <plugins>
       <plugin>
-        <groupId>org.jacoco</groupId>
+        <groupId>za.co.absa.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>${project.version}</version>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jacoco</groupId>
+  <groupId>za.co.absa.jacoco</groupId>
   <artifactId>root</artifactId>
   <version>0.8.9-SNAPSHOT</version>
   <packaging>pom</packaging>


### PR DESCRIPTION
All package and install goals related location of "org.jacoco" migrated to "za.co.absa.jacoco".
Required to used as dependency until final solution will exist.